### PR TITLE
Declare PLaMo API key in setup metadata

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -26,6 +26,16 @@
       "cliDescription": "Preferred Networks API key"
     }
   ],
+  "setup": {
+    "providers": [
+      {
+        "id": "plamo",
+        "authMethods": ["api-key"],
+        "envVars": ["PLAMO_API_KEY"]
+      }
+    ],
+    "requiresRuntime": false
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function readManifest(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, "openclaw.plugin.json"), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("OpenClaw plugin manifest", () => {
+  it("declares the PLaMo API key in descriptor-first setup metadata", () => {
+    const manifest = readManifest();
+
+    expect(manifest).toMatchObject({
+      providerAuthEnvVars: {
+        plamo: ["PLAMO_API_KEY"],
+      },
+      setup: {
+        providers: [
+          {
+            id: "plamo",
+            authMethods: ["api-key"],
+            envVars: ["PLAMO_API_KEY"],
+          },
+        ],
+        requiresRuntime: false,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Mirror `PLAMO_API_KEY` into `setup.providers[].envVars`, the preferred descriptor-first metadata surface for provider setup/status.
- Keep the existing `providerAuthEnvVars` compatibility metadata in sync.
- Add a manifest regression test for the PLaMo auth metadata contract.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

Fixes #3
