### PR TITLE
Require explicit debug opt-in for payload dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ PLaMo model names can be used before the local catalog is refreshed.
 
 ## Debugging
 
-`OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH` is an optional debugging environment
-variable. When it is set to a local file path, the provider appends one JSON
-record per PLaMo streaming payload to that file. Normal provider use does not
-require setting this variable.
+Payload dumping is an optional debugging feature. To enable it, set both
+`OPENCLAW_PLAMO_DEBUG_PAYLOAD_DUMP=1` and
+`OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH` to a local file path. The provider then
+appends one JSON record per PLaMo streaming payload to that file. Normal
+provider use does not require setting either variable.
 
 Payload dumps can include prompts, tool call payloads, tool results, and model
-responses. Leave this variable unset during normal use, and review or redact
+responses. Leave these variables unset during normal use, and review or redact
 dump files before sharing them or attaching them to issues.
 
 ## Development

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -95,7 +95,16 @@ type StreamingTextBlock = {
   streamStarted?: boolean;
 };
 
-const PLAMO_PAYLOAD_DUMP_PATH = process.env.OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH?.trim() || "";
+type PlamoPayloadDumpEnv = Partial<
+  Record<"OPENCLAW_PLAMO_DEBUG_PAYLOAD_DUMP" | "OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH", string>
+>;
+
+export function resolvePlamoPayloadDumpPath(env: PlamoPayloadDumpEnv = process.env): string {
+  if (env.OPENCLAW_PLAMO_DEBUG_PAYLOAD_DUMP?.trim() !== "1") {
+    return "";
+  }
+  return env.OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH?.trim() || "";
+}
 
 type OpenAIStyleToolCall = {
   index?: unknown;
@@ -318,17 +327,18 @@ function injectPlamoMaxTokens(
 }
 
 function dumpPlamoPayload(kind: "streaming", payload: Record<string, unknown>): void {
-  if (!PLAMO_PAYLOAD_DUMP_PATH) {
+  const dumpPath = resolvePlamoPayloadDumpPath();
+  if (!dumpPath) {
     return;
   }
   try {
-    fs.mkdirSync(path.dirname(PLAMO_PAYLOAD_DUMP_PATH), { recursive: true });
+    fs.mkdirSync(path.dirname(dumpPath), { recursive: true });
   } catch {
     // ignore dump directory failures
   }
   try {
     fs.appendFileSync(
-      PLAMO_PAYLOAD_DUMP_PATH,
+      dumpPath,
       `${JSON.stringify({ ts: Date.now(), kind, payload })}\n`,
       "utf8",
     );

--- a/test/payload-dump.test.ts
+++ b/test/payload-dump.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolvePlamoPayloadDumpPath } from "../src/stream.js";
+
+describe("PLaMo payload dump opt-in", () => {
+  it("does not enable payload dumps from a path alone", () => {
+    expect(
+      resolvePlamoPayloadDumpPath({
+        OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH: "/tmp/plamo-payloads.jsonl",
+      }),
+    ).toBe("");
+  });
+
+  it("requires the explicit debug flag and a dump path", () => {
+    expect(
+      resolvePlamoPayloadDumpPath({
+        OPENCLAW_PLAMO_DEBUG_PAYLOAD_DUMP: "1",
+        OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH: " /tmp/plamo-payloads.jsonl ",
+      }),
+    ).toBe("/tmp/plamo-payloads.jsonl");
+  });
+});


### PR DESCRIPTION
## Summary

- Require `OPENCLAW_PLAMO_DEBUG_PAYLOAD_DUMP=1` before honoring `OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH`.
- Update README debugging guidance to describe the two-variable opt-in.
- Add regression tests for the payload dump opt-in contract.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

Fixes #4
