### PR TITLE
Prepare 0.1.1 patch release

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plamo",
   "name": "Preferred Networks Provider",
   "description": "Preferred Networks PLaMo model provider plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "providers": ["plamo"],
   "nonSecretAuthMarkers": ["plamo-request-auth"],
   "modelSupport": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitmul/openclaw-plamo-provider",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenClaw provider plugin for Preferred Networks PLaMo",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump the npm package version to `0.1.1`.
- Bump `openclaw.plugin.json` to `0.1.1` so package and plugin metadata stay aligned.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm pack --dry-run`

Refs #5
