### PR TITLE
Remove deprecated provider auth metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ provider plugins as code.
 The authoritative credential metadata for this provider is:
 
 - `openclaw.plugin.json` `setup.providers[].envVars`: `PLAMO_API_KEY`
-- `openclaw.plugin.json` `providerAuthEnvVars.plamo`: `PLAMO_API_KEY`
 - `package.json` `openclaw.security.requiredEnv`: `PLAMO_API_KEY`
 
 ## Development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,6 @@ The PLaMo provider requires one primary credential: `PLAMO_API_KEY`.
 The credential is declared in:
 
 - `openclaw.plugin.json` `setup.providers[].envVars`
-- `openclaw.plugin.json` `providerAuthEnvVars.plamo`
 - `package.json` `openclaw.security.requiredEnv`
 - `package.json` `clawhub.security.requiredEnv`
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,14 +2,11 @@
   "id": "plamo",
   "name": "Preferred Networks Provider",
   "description": "Preferred Networks PLaMo model provider plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "providers": ["plamo"],
   "nonSecretAuthMarkers": ["plamo-request-auth"],
   "modelSupport": {
     "modelPrefixes": ["plamo-"]
-  },
-  "providerAuthEnvVars": {
-    "plamo": ["PLAMO_API_KEY"]
   },
   "providerAuthChoices": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitmul/openclaw-plamo-provider",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenClaw provider plugin for Preferred Networks PLaMo",
   "license": "MIT",
   "type": "module",

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -20,13 +20,10 @@ function readPackageJson(): Record<string, unknown> {
 }
 
 describe("OpenClaw plugin manifest", () => {
-  it("declares the PLaMo API key in descriptor-first setup metadata", () => {
+  it("declares the PLaMo API key only in descriptor-first setup metadata", () => {
     const manifest = readManifest();
 
     expect(manifest).toMatchObject({
-      providerAuthEnvVars: {
-        plamo: ["PLAMO_API_KEY"],
-      },
       setup: {
         providers: [
           {
@@ -44,6 +41,7 @@ describe("OpenClaw plugin manifest", () => {
         localPayloadDumps: false,
       },
     });
+    expect(manifest).not.toHaveProperty("providerAuthEnvVars");
   });
 
   it("keeps package and manifest security metadata aligned for ClawHub", () => {


### PR DESCRIPTION
## Summary
- Remove deprecated `providerAuthEnvVars` from the PLaMo plugin manifest so OpenClaw no longer emits the compatibility warning.
- Keep `PLAMO_API_KEY` declared through descriptor-first `setup.providers[].envVars` and security metadata.
- Bump the plugin package/manifest version to `0.1.4` for the warning fix release.

## Root cause
OpenClaw now warns whenever a plugin descriptor still includes `providerAuthEnvVars`. The PLaMo plugin already mirrored the credential env var to `setup.providers[].envVars`, so the legacy compatibility key was no longer needed and caused warnings on every command.

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm pack --dry-run`
- `git diff --check`