### PR TITLE
[codex] Enable PLaMo tool support

### DIFF
--- a/src/model-definitions.ts
+++ b/src/model-definitions.ts
@@ -15,6 +15,7 @@ export const PLAMO_OPENAI_COMPAT = {
   maxTokensField: "max_tokens",
   supportsDeveloperRole: false,
   supportsReasoningEffort: false,
+  supportsTools: true,
   supportsStore: false,
   supportsStrictMode: false,
 } as const satisfies NonNullable<ModelDefinitionConfig["compat"]>;


### PR DESCRIPTION
## Summary

- Enable `supportsTools` in the PLaMo OpenAI-compatible model configuration.
- Advertise tool-call support while keeping unsupported compatibility flags such as developer role, reasoning effort, store, and strict mode disabled.

## Impact

OpenClaw can route tool-capable requests through the PLaMo provider instead of treating the model as non-tool-capable.

## Validation

- `pnpm test`
- `pnpm typecheck`