### PR TITLE
Bump provider version to 1.0.0

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plamo",
   "name": "Preferred Networks Provider",
   "description": "Preferred Networks PLaMo model provider plugin",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "providers": [
     "plamo"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitmul/openclaw-plamo-provider",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "OpenClaw provider plugin for Preferred Networks PLaMo",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump the PLaMo provider package and OpenClaw plugin manifest versions from `0.1.6` to `1.0.0`.

## Impact

This prepares the provider for a v1.0.0 release while keeping the npm package metadata and OpenClaw plugin manifest aligned.

## Validation

- `pnpm test`
- `pnpm typecheck`
