### PR TITLE
Release v1.0.2

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plamo",
   "name": "Preferred Networks Provider",
   "description": "Preferred Networks PLaMo model provider plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "providers": [
     "plamo"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitmul/openclaw-plamo-provider",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenClaw provider plugin for Preferred Networks PLaMo",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump @mitmul/openclaw-plamo-provider to v1.0.2
- keep openclaw.plugin.json aligned with package.json

## Validation
- pnpm install --config.minimumReleaseAge=0
- package/manifest version alignment check
- npm view @mitmul/openclaw-plamo-provider version dist-tags versions --json confirms v1.0.2 is not published yet
- pnpm --config.minimumReleaseAge=0 typecheck
- pnpm --config.minimumReleaseAge=0 test
- pnpm --config.minimumReleaseAge=0 build
- pnpm --config.minimumReleaseAge=0 pack --dry-run