### PR TITLE
Release v1.0.3

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plamo",
   "name": "Preferred Networks Provider",
   "description": "Preferred Networks PLaMo model provider plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "providers": [
     "plamo"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitmul/openclaw-plamo-provider",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenClaw provider plugin for Preferred Networks PLaMo",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump @mitmul/openclaw-plamo-provider to v1.0.3
- keep openclaw.plugin.json aligned with package.json

## Validation
- pnpm install
- package/manifest version alignment check
- npm view and ClawHub inspect confirmed latest is currently v1.0.2
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm pack --dry-run