### PR TITLE
Handle PLaMo reasoning summaries

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plamo",
   "name": "Preferred Networks Provider",
   "description": "Preferred Networks PLaMo model provider plugin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "providers": [
     "plamo"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitmul/openclaw-plamo-provider",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OpenClaw provider plugin for Preferred Networks PLaMo",
   "license": "MIT",
   "type": "module",

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -16,7 +16,10 @@ import { resolveEnvApiKey } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   buildGuardedModelFetch,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
-import { PLAMO_REASONING_EFFORT_MAP } from "./model-definitions.js";
+import {
+  PLAMO_DEFAULT_MODEL_ID,
+  PLAMO_REASONING_EFFORT_MAP,
+} from "./model-definitions.js";
 import { PLAMO_REQUEST_AUTH_MARKER } from "./provider-catalog.js";
 import { normalizeOpenAICompatibleToolParameters } from "./tool-schema.js";
 
@@ -42,6 +45,7 @@ const PLAMO_TAG_TOKENS = [
 ] as const;
 const PLAMO_SYNTHETIC_TURN_SEED_SYMBOL = Symbol("openclaw.plamoSyntheticTurnSeed");
 const PLAMO_EMPTY_STREAM_MAX_RETRIES = 1;
+const PLAMO_REASONING_SUMMARY_DETAIL = "detailed";
 
 const PLAMO_TOOL_REQUEST_BLOCK_RE = new RegExp(
   `${escapeRegExp(PLAMO_BEGIN_TOOL_REQUEST)}(.*?)${escapeRegExp(PLAMO_END_TOOL_REQUEST)}`,
@@ -135,6 +139,7 @@ type OpenAIStyleChunkDelta = {
 type OpenAIStyleChunkChoice = {
   finish_reason?: unknown;
   delta?: OpenAIStyleChunkDelta | null;
+  reasoning_summary?: unknown;
   usage?: OpenAIStyleUsage | null;
 };
 
@@ -673,6 +678,31 @@ function resolvePlamoOptionsReasoningEffort(
   );
 }
 
+function isPlamoPrimeModel(model: RuntimeModel): boolean {
+  const normalizedId = model.id.trim().toLowerCase();
+  return (
+    normalizedId === PLAMO_DEFAULT_MODEL_ID ||
+    normalizedId === `plamo/${PLAMO_DEFAULT_MODEL_ID}`
+  );
+}
+
+function injectPlamoReasoningSummary(
+  payload: Record<string, unknown>,
+  model: RuntimeModel,
+): void {
+  if (!isPlamoPrimeModel(model) || !model.reasoning) {
+    return;
+  }
+  const existingReasoning = payload.reasoning;
+  payload.reasoning =
+    existingReasoning && typeof existingReasoning === "object" && !Array.isArray(existingReasoning)
+      ? {
+          ...existingReasoning,
+          summary: PLAMO_REASONING_SUMMARY_DETAIL,
+        }
+      : { summary: PLAMO_REASONING_SUMMARY_DETAIL };
+}
+
 function hasToolHistory(messages: AgentMessage[]): boolean {
   for (const message of messages) {
     if (message.role === "toolResult") {
@@ -753,6 +783,7 @@ function normalizePlamoStreamingPayload(
       payload.reasoning_effort = reasoningEffort;
     }
   }
+  injectPlamoReasoningSummary(payload, model);
   injectPlamoMaxTokens(payload, model, compat);
 
   const tools = payload.tools;
@@ -1075,14 +1106,26 @@ function resolveToolCallChunkIndex(toolCall: OpenAIStyleToolCall): number | null
     : null;
 }
 
-function extractStreamingReasoning(delta: OpenAIStyleChunkDelta): string {
-  for (const field of ["reasoning_content", "reasoning", "reasoning_text"] as const) {
-    const value = delta[field];
-    if (typeof value === "string" && value.length > 0) {
-      return value;
-    }
+function collectStreamingReasoningValue(value: unknown): string[] {
+  if (typeof value === "string" && value.length > 0) {
+    return [value];
   }
-  return "";
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string" && item.length > 0);
+}
+
+function extractStreamingReasoning(
+  delta: OpenAIStyleChunkDelta,
+  choice?: OpenAIStyleChunkChoice,
+): string {
+  const parts: string[] = [];
+  for (const field of ["reasoning_content", "reasoning", "reasoning_text"] as const) {
+    parts.push(...collectStreamingReasoningValue(delta[field]));
+  }
+  parts.push(...collectStreamingReasoningValue(choice?.reasoning_summary));
+  return parts.join("");
 }
 
 function createNativePlamoStream(
@@ -1228,10 +1271,7 @@ function createNativePlamoStream(
             }
           }
 
-          const delta = choice.delta;
-          if (!isOpenAIStyleChunkDelta(delta)) {
-            continue;
-          }
+          const delta = isOpenAIStyleChunkDelta(choice.delta) ? choice.delta : {};
 
           const textDelta = typeof delta.content === "string" ? delta.content : "";
           if (textDelta) {
@@ -1265,7 +1305,7 @@ function createNativePlamoStream(
             }
           }
 
-          const reasoningDelta = extractStreamingReasoning(delta);
+          const reasoningDelta = extractStreamingReasoning(delta, choice);
           if (reasoningDelta) {
             sawAssistantOutput = true;
             finishOpenToolCallBlocks();

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -22,8 +22,8 @@ vi.mock("openclaw/plugin-sdk/provider-transport-runtime", () => ({
 }));
 
 const model: Model<"openai-completions"> = {
-  id: "plamo-test",
-  name: "PLaMo Test",
+  id: "plamo-3.0-prime",
+  name: "PLaMo 3.0 Prime",
   api: "openai-completions",
   provider: "plamo",
   baseUrl: "https://api.example.test/v1",
@@ -120,6 +120,25 @@ describe("PLaMo native stream handling", () => {
     expect(body.reasoning_effort).toBe("medium");
   });
 
+  it("requests detailed reasoning summaries for PLaMo 3.0 Prime", async () => {
+    mocks.responses.push(
+      sseResponse({
+        id: "chatcmpl-reasoning-summary-request",
+        choices: [
+          {
+            delta: { content: "ok" },
+            finish_reason: "stop",
+          },
+        ],
+      }),
+    );
+
+    await runNativePlamoStream({ reasoning: "medium" });
+
+    const body = JSON.parse(String(mocks.fetch.mock.calls[0]?.[1]?.body));
+    expect(body.reasoning).toEqual({ summary: "detailed" });
+  });
+
   it("maps thinking off to PLaMo reasoning_effort none", async () => {
     mocks.responses.push(
       sseResponse({
@@ -174,6 +193,46 @@ describe("PLaMo native stream handling", () => {
     );
     expect(message.content).toEqual([
       { type: "thinking", thinking: "hidden reasoning", thinkingSignature: "reasoning_content" },
+      { type: "text", text: "visible answer" },
+    ]);
+  });
+
+  it("emits PLaMo reasoning_summary chunks as thinking blocks", async () => {
+    mocks.responses.push(
+      sseResponse(
+        {
+          id: "chatcmpl-reasoning-summary",
+          choices: [
+            {
+              delta: { content: null, reasoning: null },
+              finish_reason: null,
+              reasoning_summary: ["summary reasoning"],
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-reasoning-summary",
+          choices: [
+            {
+              delta: { content: "visible answer" },
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ),
+    );
+
+    const { events, message } = await runNativePlamoStream({ reasoning: "medium" });
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "thinking_start" }),
+        expect.objectContaining({ type: "thinking_delta", delta: "summary reasoning" }),
+        expect.objectContaining({ type: "thinking_end", content: "summary reasoning" }),
+      ]),
+    );
+    expect(message.content).toEqual([
+      { type: "thinking", thinking: "summary reasoning", thinkingSignature: "reasoning_content" },
       { type: "text", text: "visible answer" },
     ]);
   });


### PR DESCRIPTION
## Summary

- Add `reasoning: { summary: "detailed" }` to PLaMo 3.0 Prime streaming requests.
- Treat PLaMo `reasoning_summary` stream chunks as OpenClaw thinking content.
- Bump the provider package and plugin manifest version to `1.0.4`.
- Add regression tests for both the request payload and streamed summary handling.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`